### PR TITLE
Add nvidia-container-toolkit

### DIFF
--- a/guix-science-nonfree/packages/nvidia-container-toolkit.scm
+++ b/guix-science-nonfree/packages/nvidia-container-toolkit.scm
@@ -180,7 +180,7 @@
 	    (lambda* (#:key inputs outputs #:allow-other-keys)
 	      (substitute* "src/github.com/NVIDIA/nvidia-container-toolkit/internal/config/config.go"
 (("/usr/bin")
-		 "/run/current-system/profile/bin"))))
+		 (string-append #$output "/bin")))))
           (replace 'build
             (lambda arguments
               (for-each

--- a/guix-science-nonfree/packages/nvidia-container-toolkit.scm
+++ b/guix-science-nonfree/packages/nvidia-container-toolkit.scm
@@ -150,7 +150,7 @@
 	    ))
       #:tests? #f))
     (native-inputs
-     (list libseccomp nvidia-modprobe which libtirpc libcap libelf git-minimal curl tar coreutils docker go gcc-toolchain rpcsvc-proto pkgconf))
+     (list libseccomp nvidia-modprobe which libtirpc libcap libelf git-minimal curl docker go rpcsvc-proto pkgconf))
     (synopsis "Build and run containers leveraging NVIDIA GPUs")
     (description "The NVIDIA Container Toolkit allows users to build and run GPU accelerated containers. The toolkit includes a container runtime library and utilities to automatically configure containers to leverage NVIDIA GPUs.")
     (home-page "https://github.com/NVIDIA/nvidia-container-toolkit")

--- a/guix-science-nonfree/packages/nvidia-container-toolkit.scm
+++ b/guix-science-nonfree/packages/nvidia-container-toolkit.scm
@@ -19,7 +19,7 @@
 ;;; You should have received a copy of the GNU General Public License
 ;;; along with GNU Guix.  If not, see <http://www.gnu.org/licenses/>.
 
-(define-module (guix-science-nonfree packages nvidia-docker)
+(define-module (guix-science-nonfree packages nvidia-container-toolkit)
   #:use-module (guix gexp)
   #:use-module (guix git-download)
   #:use-module (guix utils)
@@ -43,7 +43,6 @@
   #:use-module (gnu packages elf)
   #:use-module (gnu packages m4)
   #:use-module (gnu packages linux)
-  #:use-module (nongnu packages nvidia)
   )
 
 (define-public nvidia-modprobe
@@ -74,14 +73,13 @@
 	  (add-after 'build 'build-static-link-libraries
 	    (lambda* (#:key inputs outputs #:allow-other-keys)
 	      (invoke "ar" "rcs" "_out/Linux_x86_64/libnvidia-modprobe-utils.a" "_out/Linux_x86_64/nvidia-modprobe-utils.o" "_out/Linux_x86_64/pci-sysfs.o")
-	      (copy-recursively "_out/Linux_x86_64/" (string-append (assoc-ref %outputs "out") "/lib"))))
+	      (copy-recursively "_out/Linux_x86_64/" (string-append #$output "/lib"))))
 	  (delete 'check)
 	  (add-after 'patch-source-shebangs 'replace-prefix
 	    (lambda* (#:key inputs outputs #:allow-other-keys)
     	      (setenv "CC" "gcc")
-	      (setenv "PREFIX" (assoc-ref %outputs "out"))
-	      (copy-recursively "modprobe-utils/" (string-append (assoc-ref %outputs "out") "/include"))
-	      #true) ; must return true for success
+	      (setenv "PREFIX" #$output)
+	      (copy-recursively "modprobe-utils/" (string-append #$output "/include")))
 	    ))
       #:tests? #f))
     (native-inputs
@@ -148,8 +146,7 @@
 		 "WITH_LIBELF ?= yes"))
     	      (substitute* "mk/common.mk"
 		(("^REVISION.*")
-		 (string-append "REVISION ?= " #$version "\n" "CC := gcc\n")))
-	      #true) ; must return true for success
+		 (string-append "REVISION ?= " #$version "\n" "CC := gcc\n"))))
 	    ))
       #:tests? #f))
     (native-inputs

--- a/guix-science-nonfree/packages/nvidia-container-toolkit.scm
+++ b/guix-science-nonfree/packages/nvidia-container-toolkit.scm
@@ -1,0 +1,203 @@
+;;; GNU Guix --- Functional package management for GNU
+;;; Copyright © 2024 Luciano Laratelli <luciano@laratel.li>
+;;; Copyright © 2024 Connor Clark <connor@psyleft.com>
+;;; Copyright © 2024 Ian FitzPatrick <ian@ianfitzpatrick.eu>
+;;;
+;;; This file is NOT part of GNU Guix, but is supposed to be used with GNU
+;;; Guix and thus has the same license.
+;;;
+;;; GNU Guix is free software; you can redistribute it and/or modify it
+;;; under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 3 of the License, or (at
+;;; your option) any later version.
+;;;
+;;; GNU Guix is distributed in the hope that it will be useful, but
+;;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with GNU Guix.  If not, see <http://www.gnu.org/licenses/>.
+
+(define-module (guix-science-nonfree packages nvidia-docker)
+  #:use-module (guix gexp)
+  #:use-module (guix git-download)
+  #:use-module (guix utils)
+  #:use-module (guix build utils)
+  #:use-module (guix packages)
+  #:use-module (guix build-system go)
+  #:use-module (guix build-system gnu)
+  #:use-module (guix licenses)
+  #:use-module (gnu packages)
+  #:use-module (gnu packages docker)
+  #:use-module (gnu packages commencement)
+  #:use-module (gnu packages onc-rpc)
+  #:use-module (gnu packages golang)
+  #:use-module (gnu packages check)
+  #:use-module (gnu packages base)
+  #:use-module (gnu packages curl)
+  #:use-module (gnu packages version-control)
+  #:use-module (gnu packages pkg-config)
+  #:use-module (gnu packages gcc)
+  #:use-module (gnu packages tls)
+  #:use-module (gnu packages elf)
+  #:use-module (gnu packages m4)
+  #:use-module (gnu packages linux)
+  #:use-module (nongnu packages nvidia)
+  )
+
+(define-public nvidia-modprobe
+  (package
+    (name "nvidia-modprobe")
+    (version "550.54.14")
+    (source (origin
+              (method git-fetch)
+              (uri (git-reference
+                    (url "https://github.com/NVIDIA/nvidia-modprobe")
+                    (commit version)))
+              (file-name (git-file-name name version))
+              (sha256
+               (base32 "1a7q03pnwk3wa0p57whwv2mvz60bv77vvvaljqzwnscpyf94q548"))))
+    (build-system gnu-build-system)
+    (arguments
+     (list
+      #:phases
+      #~(modify-phases %standard-phases
+	  (delete 'configure)
+          (add-before 'build 'set-correct-cflags
+	    (lambda* (#:key inputs outputs #:allow-other-keys)
+    	      (setenv "CFLAGS" "-fPIC")
+	      (display "setting CFLAGS\n")
+       	      (substitute* "modprobe-utils/nvidia-modprobe-utils.c"
+		(("^static int nvidia_cap_get_device_file_attrs")
+		 "int nvidia_cap_get_device_file_attrs"))))
+	  (add-after 'build 'build-static-link-libraries
+	    (lambda* (#:key inputs outputs #:allow-other-keys)
+	      (invoke "ar" "rcs" "_out/Linux_x86_64/libnvidia-modprobe-utils.a" "_out/Linux_x86_64/nvidia-modprobe-utils.o" "_out/Linux_x86_64/pci-sysfs.o")
+	      (copy-recursively "_out/Linux_x86_64/" (string-append (assoc-ref %outputs "out") "/lib"))))
+	  (delete 'check)
+	  (add-after 'patch-source-shebangs 'replace-prefix
+	    (lambda* (#:key inputs outputs #:allow-other-keys)
+    	      (setenv "CC" "gcc")
+	      (setenv "PREFIX" (assoc-ref %outputs "out"))
+	      (copy-recursively "modprobe-utils/" (string-append (assoc-ref %outputs "out") "/include"))
+	      #true) ; must return true for success
+	    ))
+      #:tests? #f))
+    (native-inputs
+     (list gcc-toolchain m4))
+    (synopsis "Load the NVIDIA kernel module and create NVIDIA character device files")
+    (description "Load the NVIDIA kernel module and create NVIDIA character device files")
+    (home-page "https://github.com/NVIDIA/nvidia-modprobe")
+    (license gpl2)))
+
+(define-public libnvidia-container
+  (package
+    (name "libnvidia-container")
+    (version "1.13.1")
+    (source (origin
+              (method git-fetch)
+              (uri (git-reference
+                    (url "https://github.com/NVIDIA/libnvidia-container")
+                    (commit (string-append "v" version))))
+              (file-name (git-file-name name version))
+      	      (patches (search-patches "libnvidia-container.patch"))
+              (sha256
+               (base32
+		"0rzvh1zhh8pi5xjzaq3nmyzpcvjy41gq8w36dp1ai11a6j2lpa99"))))
+    (build-system gnu-build-system)
+    (arguments
+     (list
+      #:phases
+      #~(modify-phases %standard-phases
+	  (delete 'configure)
+	  (delete 'build)
+	  (delete 'check)
+          (add-after 'unpack 'ensure-writable-source
+	    (lambda* (#:key inputs outputs #:allow-other-keys)
+      	      (setenv "HOME" "/tmp")
+	      (make-file-writable "src/ldcache.c")
+      	      (make-file-writable "src/ldcache.h")
+              (make-file-writable "src/nvc_info.c")))
+	  (add-after 'patch-source-shebangs 'replace-prefix
+	    (lambda* (#:key inputs outputs #:allow-other-keys)
+	      (substitute* "Makefile"
+		(("/usr/local") (assoc-ref outputs "out"))  ;this overrides the prefix
+		(("debug??libdir?") "debug")  ;ensure debug files get installed in the correct subdir
+		((".*nvidia-modprobe.mk.*") "\n")
+		(("^all: shared static tools")
+		 "all: shared tools")
+		((".*LIB_STATIC.*libdir.*$") ""))
+     	      (substitute* "mk/nvcgo.mk"
+		((".*-rf.*")
+		 "\tmkdir -p ${SRCS_DIR} && echo \"sources dir: ${SRCS_DIR}\"\n")
+		(("CURDIR./src/..PREFIX.")
+		 "CURDIR)/src/$(PREFIX)/*")) ;deleting sources fails
+              (substitute* "src/cli/libnvc.c"
+		(("libnvidia-ml.so.1")
+		 "/run/current-system/profile/lib/libnvidia-ml.so.1"))
+              (substitute* "src/nvc_internal.h"
+		(("libnvidia-ml.so.1")
+		 "/run/current-system/profile/lib/libnvidia-ml.so.1"))
+	      (setenv "C_INCLUDE_PATH" (string-append (getenv "C_INCLUDE_PATH") ":" (string-append #$libtirpc "/include/tirpc")))
+     	      (setenv "LIBRARY_PATH" (string-append (getenv "LIBRARY_PATH") ":" (string-append #$libtirpc "/lib")))
+              (setenv "LDFLAGS" (string-append (or (getenv "LDFLAGS") "") " -ltirpc -lseccomp -lcap -Wl,-rpath=" (assoc-ref outputs "out") "/lib"))
+              (setenv "CFLAGS" (string-append (or (getenv "CFLAGS") "") " -DWITH_TIRPC -g"))
+       	      (substitute* "Makefile"
+		(("^WITH_LIBELF.*no")
+		 "WITH_LIBELF ?= yes"))
+    	      (substitute* "mk/common.mk"
+		(("^REVISION.*")
+		 (string-append "REVISION ?= " #$version "\n" "CC := gcc\n")))
+	      #true) ; must return true for success
+	    ))
+      #:tests? #f))
+    (native-inputs
+     (list libseccomp nvidia-modprobe which libtirpc libcap libelf git-minimal curl tar coreutils docker go gcc-toolchain rpcsvc-proto pkgconf))
+    (synopsis "Build and run containers leveraging NVIDIA GPUs")
+    (description "The NVIDIA Container Toolkit allows users to build and run GPU accelerated containers. The toolkit includes a container runtime library and utilities to automatically configure containers to leverage NVIDIA GPUs.")
+    (home-page "https://github.com/NVIDIA/nvidia-container-toolkit")
+    (license asl2.0)))
+
+
+(define-public nvidia-container-toolkit
+  (package
+    (name "nvidia-container-toolkit")
+    (version "1.13.1")
+    (source (origin
+              (method git-fetch)
+              (uri (git-reference
+                    (url "https://github.com/NVIDIA/nvidia-container-toolkit")
+                    (commit (string-append "v" version))))
+              (file-name (git-file-name name version))
+              (sha256
+               (base32
+		"01gh57jfpcv07c4442lbf9wiy0l1iwl85ig9drpp0637gbkzgwa4"))))
+    (build-system go-build-system)
+    (arguments
+     (list
+      #:import-path "github.com/NVIDIA/nvidia-container-toolkit"
+      #:phases
+      #~(modify-phases %standard-phases
+  	  (add-after 'unpack 'fix-paths
+	    (lambda* (#:key inputs outputs #:allow-other-keys)
+	      (substitute* "src/github.com/NVIDIA/nvidia-container-toolkit/internal/config/config.go"
+(("/usr/bin")
+		 "/run/current-system/profile/bin"))))
+          (replace 'build
+            (lambda arguments
+              (for-each
+               (lambda (directory)
+		 (apply (assoc-ref %standard-phases 'build)
+			(append arguments (list #:import-path directory))))
+               '("github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-ctk"
+		 "github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-container-runtime"
+		 "github.com/NVIDIA/nvidia-container-toolkit/cmd/nvidia-container-runtime-hook")))))
+      #:tests? #f
+      #:install-source? #f))
+    (propagated-inputs
+     (list libnvidia-container))
+    (synopsis "Build and run containers leveraging NVIDIA GPUs")
+    (description "The NVIDIA Container Toolkit allows users to build and run GPU accelerated containers. The toolkit includes a container runtime library and utilities to automatically configure containers to leverage NVIDIA GPUs.")
+    (home-page "https://github.com/NVIDIA/nvidia-container-toolkit")
+    (license asl2.0)))

--- a/libnvidia-container.patch
+++ b/libnvidia-container.patch
@@ -1,0 +1,120 @@
+diff --git a/src/ldcache.c b/src/ldcache.c
+index 38bab05..ba922d9 100644
+--- a/src/ldcache.c
++++ b/src/ldcache.c
+@@ -108,40 +108,28 @@ ldcache_close(struct ldcache *ctx)
+ 
+ int
+ ldcache_resolve(struct ldcache *ctx, uint32_t arch, const char *root, const char * const libs[],
+-    char *paths[], size_t size, ldcache_select_fn select, void *select_ctx)
++		char *paths[], size_t size)
+ {
+-        char path[PATH_MAX];
+-        struct header_libc6 *h;
+-        int override;
+-
+-        h = (struct header_libc6 *)ctx->ptr;
+-        memset(paths, 0, size * sizeof(*paths));
+-
+-        for (uint32_t i = 0; i < h->nlibs; ++i) {
+-                int32_t flags = h->libs[i].flags;
+-                char *key = (char *)ctx->ptr + h->libs[i].key;
+-                char *value = (char *)ctx->ptr + h->libs[i].value;
+-
+-                if (!(flags & LD_ELF) || (flags & LD_ARCH_MASK) != arch)
+-                        continue;
+-
+-                for (size_t j = 0; j < size; ++j) {
+-                        if (!str_has_prefix(key, libs[j]))
+-                                continue;
+-                        if (path_resolve(ctx->err, path, root, value) < 0)
+-                                return (-1);
+-                        if (paths[j] != NULL && str_equal(paths[j], path))
+-                                continue;
+-                        if ((override = select(ctx->err, select_ctx, root, paths[j], path)) < 0)
+-                                return (-1);
+-                        if (override) {
+-                                free(paths[j]);
+-                                paths[j] = xstrdup(ctx->err, path);
+-                                if (paths[j] == NULL)
+-                                        return (-1);
+-                        }
+-                        break;
+-                }
+-        }
+-        return (0);
++  char path[PATH_MAX];
++  char dir[PATH_MAX] = "/run/current-system/profile/lib"; // Is it neater to refer to the /gnu/store path?
++  char lib[PATH_MAX];
++
++  memset(paths, 0, size * sizeof(*paths));
++
++  for (size_t j = 0; j < size; ++j) {
++
++    if (!strncmp(libs[j], "libvdpau_nvidia.so", 100))
++      strcat(dir, "/vdpau");
++    snprintf(lib, 100, "%s/%s", dir, libs[j]);
++
++    if (path_resolve_full(ctx->err, path, "/", lib) < 0)
++      return (-1);
++    if (!file_exists(ctx->err, path))
++      continue;
++    paths[j] = xstrdup(ctx->err, path);
++    if (paths[j] == NULL)
++      return (-1);
++
++  }
++  return (0);
+ }
+diff --git a/src/ldcache.h b/src/ldcache.h
+index 33d78dd..95b603e 100644
+--- a/src/ldcache.h
++++ b/src/ldcache.h
+@@ -50,6 +50,6 @@ void ldcache_init(struct ldcache *, struct error *, const char *);
+ int  ldcache_open(struct ldcache *);
+ int  ldcache_close(struct ldcache *);
+ int  ldcache_resolve(struct ldcache *, uint32_t, const char *, const char * const [],
+-    char *[], size_t, ldcache_select_fn, void *);
++    char *[], size_t);
+ 
+ #endif /* HEADER_LDCACHE_H */
+diff --git a/src/nvc_info.c b/src/nvc_info.c
+index 85c9a4d..2464299 100644
+--- a/src/nvc_info.c
++++ b/src/nvc_info.c
+@@ -216,15 +216,15 @@ find_library_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_
+         if (path_resolve_full(err, path, root, ldcache) < 0)
+                 return (-1);
+         ldcache_init(&ld, err, path);
+-        if (ldcache_open(&ld) < 0)
+-                return (-1);
++        //if (ldcache_open(&ld) < 0)
++        //        return (-1);
+ 
+         info->nlibs = size;
+         info->libs = array_new(err, size);
+         if (info->libs == NULL)
+                 goto fail;
+         if (ldcache_resolve(&ld, LIB_ARCH, root, libs,
+-            info->libs, info->nlibs, select_libraries_fn, info) < 0)
++            info->libs, info->nlibs) < 0)
+                 goto fail;
+ 
+         info->nlibs32 = size;
+@@ -232,13 +232,13 @@ find_library_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_
+         if (info->libs32 == NULL)
+                 goto fail;
+         if (ldcache_resolve(&ld, LIB32_ARCH, root, libs,
+-            info->libs32, info->nlibs32, select_libraries_fn, info) < 0)
++            info->libs32, info->nlibs32) < 0)
+                 goto fail;
+         rv = 0;
+ 
+  fail:
+-        if (ldcache_close(&ld) < 0)
+-                return (-1);
++        //if (ldcache_close(&ld) < 0)
++        //        return (-1);
+         return (rv);
+ }
+ 


### PR DESCRIPTION
This PR adds nvidia-container-toolkit a prerequisite to run NVIDIA GPU enabled docker containers. Please note: a dependency on nonguix as the source of the nvidia drivers is introduced as well.

`libnvidia-container.patch`: allows libnvidia container to locate nvidia libraries on the host system

Also note: in order to run the containers one must bind mount the entire /gnu/store into the container e.g.,

```sh
docker run --name pytorch -it --rm -v /gnu/store:/gnu/store:ro --runtime=nvidia -e NVIDIA_DRIVER_CAPABILITIES=compute,utility -e NVIDIA_VISIBLE_DEVICES=all --gpus all pytorch/pytorch:latest
```

You can use Python to verify you now have access to the gpu:

```
Python 3.10.13 (main, Sep 11 2023, 13:44:35) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
import torch
>>> torch.cuda.is_available()
torch.cuda.is_available()
True
```

Should the above instructions be added to the README?

For additional context please see: https://ianfitzpatrick.eu/guix-nvidia-docker/